### PR TITLE
fix: persist playback rate on in-tab navigation

### DIFF
--- a/contentScript.js
+++ b/contentScript.js
@@ -1,5 +1,7 @@
 // TODO: Check Ambient Mode
 
+let sliderContainer, slider;
+
 const createControls = () => {
     const controlsExist = document.getElementsByClassName("ytease-controls")[0];
 
@@ -22,18 +24,21 @@ const createControls = () => {
 
         yteaseControls.appendChild(createSlider());
         ytContainer.appendChild(yteaseControls);
+    } else {
+        setPlaybackRate(slider.value);
     }
 }
 
 const createSlider = () => {
-    const sliderContainer = document.createElement("div");
+    if (sliderContainer) return sliderContainer;
+    sliderContainer = document.createElement("div");
     sliderContainer.style.cssText = `
             display: flex;
             align-items: center;
             width: 100%;
         `
 
-    const slider = document.createElement("input");
+    slider = document.createElement("input");
     slider.type = "range"
     slider.min = 0.25;
     slider.max = 5.0;


### PR DESCRIPTION
Fixes #4 
This commit persists playback rate on navigation in the same tab. That is if a user sets a playback speed for a video and then checks out to a new video in the same tab, then the playback rate is persisted. However, if the user wishes to watch a video in another tab the playback rate is set 1x only.